### PR TITLE
Fix typo setting progress bar message.

### DIFF
--- a/app/templates/_index.html
+++ b/app/templates/_index.html
@@ -57,7 +57,7 @@
 			<div id="second">
 				<!-- fill the second view with content -->
 				<p>2nd view</p>
-				<d-progress-bar value=30 max="100" essage="Uploading..." style="width: 50%"></d-progress-bar>
+				<d-progress-bar value=30 max="100" message="Uploading..." style="width: 50%"></d-progress-bar>
 			</div>
 			<div id="third">
 				<!-- fill the third view with content -->


### PR DESCRIPTION
Just noticed a typo that prevented the progress bar message from displaying.
